### PR TITLE
Addons, Options, Themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ const MyTerminal = () => {
 };
 ```
 
+If you would like to customize the colors of the terminal, you can use the `theme` property on the options object. This property accepts a partial ITheme type, and any properties not provided will be filled in with the default values. For more information on the ITheme type, see the [xterm.js docs](https://xtermjs.org/docs/api/terminal/interfaces/itheme/).
+
+```tsx
+const MyTerminal = () => {
+  return (
+    <XTerm
+      options={{
+        theme: {
+          background: '#101010',
+          foreground: '#fdfdfd',
+        },
+      }}
+    />
+  );
+};
+```
+
 ## XTerm Addons
 
 XTerm.js has a number of [addons](https://xtermjs.org/docs/addons/) that can be used to extend the functionality of the terminal. There are officially supported addons as well as community-developed addons available. To use an addon, you must first import the addon class and then pass it as-is to the XTerm component as a prop. You do not need to instantiate the addon.
@@ -123,4 +140,4 @@ const MyTerminal = () => {
 
 ## Contributing
 
-I'm new to SolidJS. You may have some better ideas regarding this component. If you're interested in contributing, please open an issue first to discuss what you would like to change.
+I'm new to SolidJS and its reactivity patterns. You may have some better ideas regarding how this component is designed. If you're interested in contributing, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,39 @@ Please reference the [xterm.js docs](https://xtermjs.org/docs/) for additional i
 | onTitleChange     | Invoked when an OSC 0 or OSC 2 title change occurs                       | title: string, terminal: Terminal                                   |
 | onWriteParsed     | Invoked when data has been parsed by the terminal, after write is called | terminal: Terminal                                                  |
 
+## Options
+
+The XTerm component accepts all the same options as the [xterm.js Terminal constructor](https://xtermjs.org/docs/api/terminal/interfaces/iterminaloptions/). These options can be passed as props to the component.
+
+```tsx
+const MyTerminal = () => {
+
+  return (
+    <XTerm
+      options={{
+        cursorBlink: true,
+        fontFamily: 'Roboto Mono',
+        lineHeight: 1.2,
+        ...
+      }}
+    />
+  );
+};
+```
+
+## XTerm Addons
+
+XTerm.js has a number of [addons](https://xtermjs.org/docs/addons/) that can be used to extend the functionality of the terminal. There are officially supported addons as well as community-developed addons available. To use an addon, you must first import the addon class and then pass it as-is to the XTerm component as a prop. You do not need to instantiate the addon.
+
+```tsx
+import { FitAddon } from '@xterm/addon-fit';
+import { WebglAddon } from '@xterm/addon-webgl';
+
+const MyTerminal = () => {
+  return <XTerm addons={[FitAddon, WebglAddon]} />;
+};
+```
+
 ## Contributing
 
 I'm new to SolidJS. You may have some better ideas regarding this component. If you're interested in contributing, please open an issue first to discuss what you would like to change.

--- a/index.ts
+++ b/index.ts
@@ -11,4 +11,5 @@ export type {
   ITerminalOptions,
   ITerminalInitOnlyOptions,
   ITerminalAddon,
+  ITheme,
 } from 'xterm';

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,14 @@
 export { default as XTerm } from './src/XTerm.tsx';
 
-export type { XTermProps } from './src/XTerm.tsx';
+export type {
+  XTermProps,
+  OnMountCleanup,
+  ITerminalAddonConstructor,
+} from './src/XTerm.tsx';
+
 export type {
   Terminal,
   ITerminalOptions,
   ITerminalInitOnlyOptions,
+  ITerminalAddon,
 } from 'xterm';

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.4",
     "@testing-library/jest-dom": "^6.1.4",
+    "@xterm/addon-fit": "^0.9.0-beta.1",
     "jsdom": "^22.1.0",
     "typescript": "^5.2.2",
     "vite": "^5.0.0",

--- a/src/XTerm.tsx
+++ b/src/XTerm.tsx
@@ -8,6 +8,8 @@ import {
 import '../node_modules/xterm/css/xterm.css';
 
 export type OnMountCleanup = () => void | (() => Promise<void>) | undefined;
+
+export type ITerminalAddonConstructor = new (...args: any[]) => ITerminalAddon;
 export interface XTermProps {
   /**
    * The CSS classes that will be applied to the terminal container.
@@ -32,7 +34,7 @@ export interface XTermProps {
    * <XTerm addons={[SearchAddon, FitAddon]} />
    * ```
    */
-  addons?: ITerminalAddon[];
+  addons?: ITerminalAddonConstructor[];
 
   /**
    * On mount, this callback will be called with the terminal instance.
@@ -168,7 +170,7 @@ const XTerm = ({
     newTerminal.open(terminalContainerRef);
 
     addons.forEach((addon) => {
-      newTerminal?.loadAddon(addon);
+      newTerminal?.loadAddon(new addon());
     });
 
     setTerminal(newTerminal);

--- a/tests/integration.test.tsx
+++ b/tests/integration.test.tsx
@@ -3,6 +3,7 @@
 import { render } from '@solidjs/testing-library';
 import { beforeAll, describe, expect, it } from 'vitest';
 import XTerm from '../src/XTerm';
+import { FitAddon } from '@xterm/addon-fit';
 
 describe('integration tests', () => {
   beforeAll(() => {});
@@ -33,6 +34,14 @@ describe('integration tests', () => {
     const { findByText, unmount } = render(() => <App />);
 
     expect(await findByText('Hello, World!')).toBeTruthy();
+    unmount();
+  });
+
+  it('should allow addons', async () => {
+    const App = () => {
+      return <XTerm addons={[FitAddon]} />;
+    };
+    const { unmount } = render(() => <App />);
     unmount();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -663,6 +663,11 @@
     loupe "^2.3.6"
     pretty-format "^29.5.0"
 
+"@xterm/addon-fit@^0.9.0-beta.1":
+  version "0.9.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.9.0-beta.1.tgz#db1580c99e8b46f05d4006e7315dfe5f50215ddc"
+  integrity sha512-HmGRUMMamUpQYuQBF2VP1LJ0xzqF85LMFfpaNu84t1Tsrl1lPKJWtqX9FDZ22Rf5q6bnKdbj44TRVAUHgDRbLA==
+
 abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"


### PR DESCRIPTION
Fix Addons so that only a constructor needs to be passed down in the addons prop
Forward types from XTerm for ITerminalAddon, ITheme
Add notes in Readme about using Addons, Options, and Themes
