### PR TITLE
Executable Addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,25 @@ const MyTerminal = () => {
 
 ## XTerm Addons
 
-XTerm.js has a number of [addons](https://xtermjs.org/docs/addons/) that can be used to extend the functionality of the terminal. There are officially supported addons as well as community-developed addons available. To use an addon, you must first import the addon class and then pass it as-is to the XTerm component as a prop. You do not need to instantiate the addon.
+XTerm.js has a number of [addons](https://xtermjs.org/docs/addons/) that can be used to extend the functionality of the terminal. There are officially supported addons as well as community-developed addons available.
+
+To use an addon, you must first import the addon class and then either pass it as-is, or instantiate it first before passing it to the XTerm component in an array.
 
 ```tsx
 import { FitAddon } from '@xterm/addon-fit';
-import { WebglAddon } from '@xterm/addon-webgl';
+import { SearchAddon } from '@xterm/addon-search';
 
 const MyTerminal = () => {
-  return <XTerm addons={[FitAddon, WebglAddon]} />;
+  const searchAddon = createMemo(() => new SearchAddon());
+
+  // This is just an example function demonstrating a use case where some addons may need
+  // to be accessed after passing to the XTerm component. Memoization is recommended for this.
+  const handleSearch = (search: string) => {
+    searchAddon().findNext(search);
+  };
+
+  // You can pass either an ITerminalAddon constructor or an instance, depending on whether you need to access it later.
+  return <XTerm addons={[FitAddon, searchAddon]} />;
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ const MyTerminal = () => {
   };
 
   // You can pass either an ITerminalAddon constructor or an instance, depending on whether you need to access it later.
-  return <XTerm addons={[FitAddon, searchAddon]} />;
+  return <XTerm addons={[FitAddon, searchAddon()]} />;
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.3",
   "type": "module",
   "author": "WVAviator",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WVAviator/solid-xterm.git"
+  },
   "license": "MIT",
   "scripts": {
     "test": "vitest --no-threads"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-xterm",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "type": "module",
   "author": "WVAviator",
   "license": "MIT",

--- a/src/XTerm.tsx
+++ b/src/XTerm.tsx
@@ -34,7 +34,7 @@ export interface XTermProps {
    * <XTerm addons={[SearchAddon, FitAddon]} />
    * ```
    */
-  addons?: ITerminalAddonConstructor[];
+  addons?: (ITerminalAddonConstructor | ITerminalAddon)[];
 
   /**
    * On mount, this callback will be called with the terminal instance.
@@ -170,7 +170,11 @@ const XTerm = ({
     newTerminal.open(terminalContainerRef);
 
     addons.forEach((addon) => {
-      newTerminal?.loadAddon(new addon());
+      if (typeof addon === 'function') {
+        newTerminal?.loadAddon(new addon());
+      } else {
+        newTerminal?.loadAddon(addon);
+      }
     });
 
     setTerminal(newTerminal);

--- a/src/XTerm.tsx
+++ b/src/XTerm.tsx
@@ -23,7 +23,8 @@ export interface XTermProps {
   options?: ITerminalOptions & ITerminalInitOnlyOptions;
 
   /**
-   * An array of addons that will be loaded into XTerm. A list of officially supported addons can be found at https://github.com/xtermjs/xterm.js/tree/master/addons/
+   * An array of addons that will be loaded into XTerm. Addons can be passed as either an instance or a constructor.
+   * @see https://xtermjs.org/docs/api/addons/
    * @example
    * ```tsx
    * import { SearchAddon } from 'xterm-addon-search';
@@ -31,7 +32,9 @@ export interface XTermProps {
    *
    * ...
    *
-   * <XTerm addons={[SearchAddon, FitAddon]} />
+   * const searchAddon = createMemo(() => new SearchAddon());
+   *
+   * <XTerm addons={[searchAddon(), FitAddon]} />
    * ```
    */
   addons?: (ITerminalAddonConstructor | ITerminalAddon)[];


### PR DESCRIPTION
Addon prop can now take either an Addon constructor or an Addon instance
Users can memoize addon instances for use after terminal creation
Updated tests to verify this feature works
Updated documentation to highlight this feature for users