### PR TITLE
Update xterm version and package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-xterm",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "author": "WVAviator",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test": "vitest --no-threads"
   },
   "dependencies": {
-    "solid-js": "^1.8.5",
-    "xterm": "^5.3.0"
+    "@xterm/xterm": "^5.5.0",
+    "solid-js": "^1.8.5"
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.4",

--- a/src/XTerm.tsx
+++ b/src/XTerm.tsx
@@ -4,8 +4,8 @@ import {
   ITerminalInitOnlyOptions,
   ITerminalOptions,
   Terminal,
-} from 'xterm';
-import '../node_modules/xterm/css/xterm.css';
+} from '@xterm/xterm';
+import '../node_modules/@xterm/xterm/css/xterm.css';
 
 export type OnMountCleanup = () => void | (() => Promise<void>) | undefined;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -668,6 +668,11 @@
   resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.9.0-beta.1.tgz#db1580c99e8b46f05d4006e7315dfe5f50215ddc"
   integrity sha512-HmGRUMMamUpQYuQBF2VP1LJ0xzqF85LMFfpaNu84t1Tsrl1lPKJWtqX9FDZ22Rf5q6bnKdbj44TRVAUHgDRbLA==
 
+"@xterm/addon-search@^0.14.0-beta.1":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-search/-/addon-search-0.14.0.tgz#783c1a3fb301a98f0d0598453bd80d22cb0863ed"
+  integrity sha512-gyKIjC1c2bqxBevPmWlMWRsHqiufUgl3HjN3OYim6YPClqNRUlTab7l8aW8i3W83XzU9q0gmAfIOe4KDmo0GfQ==
+
 "@xterm/xterm@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.5.0.tgz#275fb8f6e14afa6e8a0c05d4ebc94523ff775396"

--- a/yarn.lock
+++ b/yarn.lock
@@ -668,6 +668,11 @@
   resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.9.0-beta.1.tgz#db1580c99e8b46f05d4006e7315dfe5f50215ddc"
   integrity sha512-HmGRUMMamUpQYuQBF2VP1LJ0xzqF85LMFfpaNu84t1Tsrl1lPKJWtqX9FDZ22Rf5q6bnKdbj44TRVAUHgDRbLA==
 
+"@xterm/xterm@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.5.0.tgz#275fb8f6e14afa6e8a0c05d4ebc94523ff775396"
+  integrity sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==
+
 abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -2015,11 +2020,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xterm@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.3.0.tgz#867daf9cc826f3d45b5377320aabd996cb0fce46"
-  integrity sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
Update NPM package for XTerm library from 'xterm' to '@xterm/xterm' and version 5.5.0.
Published package 0.2.0 with updates.

Closes #5 